### PR TITLE
fix(fuse): copy retained decoder bytes

### DIFF
--- a/src/fuse/notify.ts
+++ b/src/fuse/notify.ts
@@ -130,7 +130,10 @@ export function decodeNotify(message: Uint8Array): FuseNotification {
       `fuse_out_header.len is ${len} but only ${message.length} byte(s) were read`,
     );
   }
-  return { code, body: message.slice(FUSE_OUT_HEADER_SIZE, len) };
+  return {
+    code,
+    body: Uint8Array.prototype.slice.call(message, FUSE_OUT_HEADER_SIZE, len),
+  };
 }
 
 /** Decode a `FUSE_NOTIFY_INVAL_INODE` body. */

--- a/src/fuse/protocol.ts
+++ b/src/fuse/protocol.ts
@@ -25,8 +25,8 @@
  * - **Decoding is total.** A truncated or malformed buffer throws
  *   {@link ProtocolError} and nothing else — never a `RangeError`, never silent
  *   garbage.
- * - **Decoders copy.** Byte payloads are `slice()`d out of the input so a
- *   transport can reuse its receive buffer.
+ * - **Decoders copy.** Byte payloads are copied out of the input so a transport
+ *   can reuse its receive buffer.
  * - Names are decoded as UTF-8 `string`s (lossy for names that are not valid
  *   UTF-8 — see IDEA.md's note that keys are really bytes) and may not contain
  *   a NUL.
@@ -201,6 +201,8 @@ export function readWriteInSize(minor: number): number {
 const textDecoder = new TextDecoder("utf-8");
 const textEncoder = new TextEncoder();
 const EMPTY_BYTES = new Uint8Array(0);
+const copyBytes = (bytes: Uint8Array, start?: number, end?: number): Uint8Array =>
+  Uint8Array.prototype.slice.call(bytes, start, end);
 
 /** A cursor over a request/reply body. Every read is bounds-checked. */
 class Reader {
@@ -255,7 +257,7 @@ class Reader {
   /** A copy of the next `size` bytes. */
   raw(size: number): Uint8Array {
     const at = this.take(size);
-    return this.bytes.slice(at, at + size);
+    return copyBytes(this.bytes, at, at + size);
   }
 
   /** A NUL-terminated name. */
@@ -782,7 +784,7 @@ export interface FuseRawData {
 }
 
 function decodeRawData(body: Uint8Array): FuseRawData {
-  return { data: body.slice() };
+  return { data: copyBytes(body) };
 }
 
 function encodeRawData(value: FuseRawData): Uint8Array {
@@ -2751,12 +2753,12 @@ export function decodeRequest(buffer: Uint8Array, ctx?: ProtocolContext): FuseRe
     );
   }
   const payload = buffer.subarray(FUSE_IN_HEADER_SIZE, bodyEnd);
-  const extensions = buffer.slice(bodyEnd, header.len);
+  const extensions = copyBytes(buffer, bodyEnd, header.len);
   const spec = OPCODES.get(header.opcode);
   return {
     header,
     name: opcodeName(header.opcode),
-    payload: payload.slice(),
+    payload: copyBytes(payload),
     extensions,
     body: spec === undefined ? undefined : spec.decodeRequest(payload, ctxOf(ctx)),
   };
@@ -2829,7 +2831,7 @@ export function decodeReply(buffer: Uint8Array, opcode: number, ctx?: ProtocolCo
       `fuse_out_header.len is ${header.len} but only ${buffer.length} byte(s) were read`,
     );
   }
-  const payload = buffer.slice(FUSE_OUT_HEADER_SIZE, header.len);
+  const payload = copyBytes(buffer, FUSE_OUT_HEADER_SIZE, header.len);
   const spec = OPCODES.get(opcode);
   return {
     header,

--- a/test/fuse/protocol.test.ts
+++ b/test/fuse/protocol.test.ts
@@ -5,6 +5,7 @@ import {
   FUSE_GETXATTR,
   FUSE_IN_HEADER_SIZE,
   FUSE_LOOKUP,
+  FUSE_NOTIFY_INVAL_INODE,
   FUSE_OPEN,
   FUSE_OUT_HEADER_SIZE,
   FUSE_READ,
@@ -14,6 +15,7 @@ import {
   OPCODE_NAMES,
   opcodeName,
 } from "../../src/fuse/constants.ts";
+import { decodeNotify, encodeNotify } from "../../src/fuse/notify.ts";
 import {
   attrOutSize,
   attrSize,
@@ -59,7 +61,7 @@ import {
   SUPPORTED_OPCODES,
   UNIMPLEMENTED_OPCODES,
 } from "../../src/fuse/protocol.ts";
-import type { ProtocolContext } from "../../src/fuse/protocol.ts";
+import type { FuseRawData, FuseWriteIn, ProtocolContext } from "../../src/fuse/protocol.ts";
 import {
   randomAttr,
   randomAttrOut,
@@ -249,6 +251,68 @@ describe("round-trips", () => {
       expect(decoded.header).toEqual({ len: message.length, error: 0, unique });
       expect(decoded.body).toEqual(entry);
     }
+  });
+});
+
+describe("retained bytes", () => {
+  it("copies Buffer-backed request bytes before the transport reuses them", () => {
+    const data = new Uint8Array([1, 2, 3, 4]);
+    const extensions = new Uint8Array([5, 6, 7, 8, 9, 10, 11, 12]);
+    const encoded = encodeRequest({
+      opcode: FUSE_WRITE,
+      unique: 1n,
+      nodeid: 2n,
+      body: {
+        fh: 3n,
+        offset: 4n,
+        size: data.length,
+        writeFlags: 0,
+        lockOwner: 5n,
+        flags: 0,
+        data,
+      } satisfies FuseWriteIn,
+      extensions,
+    });
+    const message = Buffer.allocUnsafe(encoded.length);
+    message.set(encoded);
+    const decoded = decodeRequest(message);
+    const payload = new Uint8Array(decoded.payload);
+
+    message.fill(0xaa);
+
+    expect([...decoded.payload]).toEqual([...payload]);
+    expect([...decoded.extensions]).toEqual([...extensions]);
+    expect([...(decoded.body as FuseWriteIn).data]).toEqual([...data]);
+  });
+
+  it("copies Buffer-backed reply bytes before the caller reuses them", () => {
+    const data = new Uint8Array([13, 14, 15, 16]);
+    const message = Buffer.from(encodeReplyFor(6n, FUSE_READ, { data } satisfies FuseRawData));
+    const decoded = decodeReply(message, FUSE_READ);
+
+    message.fill(0xbb);
+
+    expect([...decoded.payload]).toEqual([...data]);
+    expect([...(decoded.body as FuseRawData).data]).toEqual([...data]);
+  });
+
+  it("copies a directly decoded Buffer-backed raw body", () => {
+    const message = Buffer.from([17, 18, 19, 20]);
+    const decoded = decodeReplyBody(FUSE_READ, message) as FuseRawData;
+
+    message.fill(0xcc);
+
+    expect([...decoded.data]).toEqual([17, 18, 19, 20]);
+  });
+
+  it("copies a Buffer-backed notification body", () => {
+    const body = new Uint8Array([21, 22, 23, 24]);
+    const message = Buffer.from(encodeNotify(FUSE_NOTIFY_INVAL_INODE, body));
+    const decoded = decodeNotify(message);
+
+    message.fill(0xdd);
+
+    expect([...decoded.body]).toEqual([...body]);
   });
 });
 


### PR DESCRIPTION
I am working on ViteHub. I am migrating the Vitehub Workspaces to use mountx, as I prefer to have a library made by you rather than using my own.

My idea of ViteHub Workspace is to create a file system in any provider cloud so ai models and harnesses can operate.

https://vitehub.dev/docs/agents/workspace-context/

I hope you find the PRs I am submitting useful and I look forward to see what you build!


## Summary

- copy every FUSE decoder byte sequence that survives decoding, even when the input is a Node `Buffer`
- cover request payloads, extensions, `WRITE` data, reply payloads, raw reply data, and notification bodies with Buffer-overwrite regressions

## Why

The FUSE transport reads into pooled `Buffer`s, dispatches without awaiting the driver, and immediately re-arms the receive buffer. The decoders used `.slice()` at six retention points, but `Buffer.prototype.slice()` returns a shared-memory view, so a delayed driver write could consume bytes from a later request and silently corrupt file data.

This restores mountx's existing ownership contract rather than changing it: [`AGENTS.md`](https://github.com/pithings/mountx/blob/ffc0f66022f53a20ac57edb8c54af4ba4948f49d/AGENTS.md) says sessions copy everything retained before their first `await` and decoders copy retained bytes. The NFS decoder already uses the same `Uint8Array.prototype.slice.call` spelling.

This addresses [issue #1, Group A item 1](https://github.com/pithings/mountx/issues/1). It deliberately excludes Group A's lazy-payload and framed-reply performance work, every other issue group, and any API change.

## Verification

- reproduced before the fix: all four Buffer-overwrite regressions failed
- `pnpm vitest run test/fuse/protocol.test.ts` — 60 passed
- `pnpm test` — 28 files passed, 887 tests passed, 197 skipped; includes lint and typecheck
- `pnpm build`
- real Linux 6.12 `/dev/fuse` in a privileged disposable container:
  - `test/fuse/mount.test.ts` — 19 passed
  - `test/fuse/differential.test.ts` — 3 passed
  - `test/fuse/conformance-mount.test.ts` — 126 passed

The combined Tier-2 command also attempted the unrelated NFS mount file; its four mount cases could not run because the disposable image had no `/sbin/mount.nfs`. The complete Tier-0/Tier-1 NFS suite passed under `pnpm test`.
