### PR TITLE
fix(unstorage): preserve open files across rename

### DIFF
--- a/src/drivers/unstorage.ts
+++ b/src/drivers/unstorage.ts
@@ -102,6 +102,7 @@ interface Attributes {
 
 /** A file's contents while something has it open. Shared by every handle on the path. */
 interface OpenFile extends ByteHolder {
+  path: string;
   data: Uint8Array;
   /** Open handles. The write-back happens when this reaches zero. */
   refs: number;
@@ -223,7 +224,7 @@ export function createUnstorageDriver(
   function movePaths(from: string, to: string): void {
     const remap = (path: string): string => normalizePath(to + path.slice(from.length));
 
-    function move<T>(records: Map<string, T>): void {
+    function move<T>(records: Map<string, T>, moved?: (path: string, value: T) => void): void {
       const affected: [string, T][] = [];
       for (const record of records) {
         if (isPathInside(record[0], from)) {
@@ -231,12 +232,16 @@ export function createUnstorageDriver(
         }
       }
       for (const [path, value] of affected) {
+        const destination = remap(path);
         records.delete(path);
-        records.set(remap(path), value);
+        records.set(destination, value);
+        moved?.(destination, value);
       }
     }
 
-    move(openFiles);
+    move(openFiles, (path, entry) => {
+      entry.path = path;
+    });
     move(attributes);
 
     const directories: string[] = [];
@@ -472,39 +477,48 @@ export function createUnstorageDriver(
       raced.refs++;
       return raced;
     }
-    const entry: OpenFile = { data, refs: 1, dirty: false, orphan: false };
+    const entry: OpenFile = { path, data, refs: 1, dirty: false, orphan: false };
     openFiles.set(path, entry);
     return entry;
   }
 
-  async function flush(path: string, entry: OpenFile): Promise<void> {
+  async function flush(entry: OpenFile): Promise<void> {
     if (!entry.dirty || entry.orphan) {
       return;
     }
     entry.dirty = false;
-    await writeValue(path, entry.data, "fsync");
-  }
-
-  async function release(path: string, entry: OpenFile): Promise<void> {
-    entry.refs--;
     try {
-      await flush(path, entry);
-    } finally {
-      // Only once nothing else holds it: the buffer *is* the file's contents
-      // while it is open, and dropping it early would lose an unflushed write.
-      if (entry.refs === 0 && openFiles.get(path) === entry) {
-        openFiles.delete(path);
-      }
+      await writeValue(entry.path, entry.data, "fsync");
+    } catch (error) {
+      entry.dirty = true;
+      throw error;
     }
   }
 
-  function createFileHandle(path: string, entry: OpenFile, flags: OpenFlags): FileHandleLike {
+  function removeClosed(entry: OpenFile): void {
+    if (entry.refs === 0 && (!entry.dirty || entry.orphan) && openFiles.get(entry.path) === entry) {
+      openFiles.delete(entry.path);
+    }
+  }
+
+  async function release(entry: OpenFile): Promise<void> {
+    entry.refs--;
+    try {
+      await flush(entry);
+    } finally {
+      // Only once nothing else holds it: the buffer *is* the file's contents
+      // while it is open, and dropping it early would lose an unflushed write.
+      removeClosed(entry);
+    }
+  }
+
+  function createFileHandle(entry: OpenFile, flags: OpenFlags): FileHandleLike {
     let position = 0;
     let closed = false;
 
     function begin(syscall: string, write: boolean): void {
       if (closed || (write ? !flags.write : !flags.read)) {
-        throw fsError("EBADF", { syscall, path });
+        throw fsError("EBADF", { syscall, path: entry.path });
       }
     }
 
@@ -537,30 +551,30 @@ export function createUnstorageDriver(
           position = from + count;
         }
         entry.dirty = true;
-        touch(path);
+        touch(entry.path);
         return { bytesWritten: count, buffer };
       },
 
       async stat() {
         if (closed) {
-          throw fsError("EBADF", { syscall: "fstat", path });
+          throw fsError("EBADF", { syscall: "fstat", path: entry.path });
         }
-        return fileStats(path, "fstat", entry);
+        return fileStats(entry.path, "fstat", entry);
       },
 
       async truncate(length = 0) {
         begin("ftruncate", true);
         resizeBytes(entry, length);
         entry.dirty = true;
-        touch(path);
+        touch(entry.path);
       },
 
       async sync() {
-        await flush(path, entry);
+        await flush(entry);
       },
 
       async datasync() {
-        await flush(path, entry);
+        await flush(entry);
       },
 
       async close() {
@@ -568,7 +582,7 @@ export function createUnstorageDriver(
           return;
         }
         closed = true;
-        await release(path, entry);
+        await release(entry);
       },
     };
   }
@@ -697,7 +711,7 @@ export function createUnstorageDriver(
         // The file exists from here on, not from the first flush: `open(O_CREAT)`
         // is what creates it, and everything else asking has to see that.
         await writeValue(resolved, EMPTY, "open");
-        return createFileHandle(resolved, await acquire(resolved, EMPTY), parsed);
+        return createFileHandle(await acquire(resolved, EMPTY), parsed);
       }
       if (parsed.exclusive) {
         throw fsError("EEXIST", { syscall: "open", path: resolved });
@@ -714,7 +728,7 @@ export function createUnstorageDriver(
         entry.dirty = true;
         touch(resolved);
       }
-      return createFileHandle(resolved, entry, parsed);
+      return createFileHandle(entry, parsed);
     },
 
     async mkdir(path, mkdirOptions: MkdirOptions = {}) {
@@ -855,7 +869,14 @@ export function createUnstorageDriver(
         // happens on flush like every other change made through a handle.
         resizeBytes(entry, length);
         entry.dirty = true;
-        touch(resolved);
+        touch(entry.path);
+        if (entry.refs === 0) {
+          try {
+            await flush(entry);
+          } finally {
+            removeClosed(entry);
+          }
+        }
         return;
       }
       const holder: ByteHolder = { data: copyOf(await readValue(resolved, "truncate")) };

--- a/test/conformance.ts
+++ b/test/conformance.ts
@@ -485,6 +485,31 @@ export function conformance(target: ConformanceTarget): void {
         expect(await read("/dst/moved/deep/file")).toBe("payload");
       });
 
+      itNeeds("handles")("keeps an open file attached across rename", async () => {
+        await fs.writeFile("/from", "aaaa");
+        const handle = await fs.open("/from", "r+");
+        await handle.write(new TextEncoder().encode("bb"), 0, 2, 0);
+        await fs.rename("/from", "/to");
+        await handle.write(new TextEncoder().encode("cc"), 0, 2, 2);
+        await handle.close();
+
+        await rejects(fs.stat("/from"), "ENOENT");
+        expect(await read("/to")).toBe("bbcc");
+      });
+
+      itNeeds("handles")("keeps an open file attached across ancestor rename", async () => {
+        await fs.mkdir("/from");
+        await fs.writeFile("/from/file", "aaaa");
+        const handle = await fs.open("/from/file", "r+");
+        await handle.write(new TextEncoder().encode("bb"), 0, 2, 0);
+        await fs.rename("/from", "/to");
+        await handle.write(new TextEncoder().encode("cc"), 0, 2, 2);
+        await handle.close();
+
+        await rejects(fs.stat("/from"), "ENOENT");
+        expect(await read("/to/file")).toBe("bbcc");
+      });
+
       it("renames a directory onto an empty directory", async () => {
         await fs.mkdir("/a");
         await fs.writeFile("/a/f", "x");

--- a/test/unstorage.test.ts
+++ b/test/unstorage.test.ts
@@ -7,8 +7,12 @@
  * flat key space.
  */
 
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { createStorage, prefixStorage } from "unstorage";
+import fsLiteStorageDriver from "unstorage/drivers/fs-lite";
 import memoryStorageDriver from "unstorage/drivers/memory";
 import { createUnstorageDriver } from "../src/drivers/unstorage.ts";
 import { createLoopback } from "../src/harness.ts";
@@ -23,6 +27,34 @@ function setup(options?: Parameters<typeof createUnstorageDriver>[1]): {
 } {
   const storage = createStorage();
   return { fs: createLoopback(createUnstorageDriver(storage, options)), storage };
+}
+
+function setupFailingWrites(): {
+  fs: Loopback;
+  storage: Storage;
+  failNextWrite: () => void;
+} {
+  const backing = memoryStorageDriver();
+  let fail = false;
+  const storage = createStorage({
+    driver: {
+      ...backing,
+      async setItemRaw(key, value, options) {
+        if (fail) {
+          fail = false;
+          throw new Error("transient write failure");
+        }
+        await backing.setItemRaw!(key, value, options);
+      },
+    },
+  });
+  return {
+    fs: createLoopback(createUnstorageDriver(storage)),
+    storage,
+    failNextWrite: () => {
+      fail = true;
+    },
+  };
 }
 
 const read = async (fs: Loopback, path: string): Promise<string> =>
@@ -274,6 +306,124 @@ describe("unstorage driver: handles", () => {
 
     expect(await read(fs, "/target")).toBe("source");
     expect(await storage.hasItem("source")).toBe(false);
+  });
+
+  it("writes an open file back only at its renamed key", async () => {
+    const { fs, storage } = setup();
+    await fs.writeFile("/from", "aaaa");
+    const handle = await fs.open("/from", "r+");
+    await handle.write(new TextEncoder().encode("bb"), 0, 2, 0);
+    await fs.rename("/from", "/to");
+    await handle.write(new TextEncoder().encode("cc"), 0, 2, 2);
+    await handle.close();
+
+    expect(await storage.hasItem("from")).toBe(false);
+    expect(await stored(storage, "to")).toBe("bbcc");
+  });
+
+  it("retries dirty data after a failed last close", async () => {
+    const { fs, storage, failNextWrite } = setupFailingWrites();
+    await fs.writeFile("/f", "aaaa");
+    const handle = await fs.open("/f", "r+");
+    await handle.write(new TextEncoder().encode("bbbb"), 0, 4, 0);
+
+    failNextWrite();
+    await expect(handle.close()).rejects.toThrow("transient write failure");
+    expect(await stored(storage, "f")).toBe("aaaa");
+
+    const retry = await fs.open("/f", "r+");
+    await retry.sync!();
+    await retry.close();
+    expect(await stored(storage, "f")).toBe("bbbb");
+  });
+
+  it("persists path truncation after a failed last close", async () => {
+    const { fs, storage, failNextWrite } = setupFailingWrites();
+    await fs.writeFile("/f", "aaaa");
+    const handle = await fs.open("/f", "r+");
+    await handle.write(new TextEncoder().encode("bbbb"), 0, 4, 0);
+
+    failNextWrite();
+    await expect(handle.close()).rejects.toThrow("transient write failure");
+    await fs.truncate("/f", 2);
+
+    expect(await stored(storage, "f")).toBe("bb");
+    const fresh = createLoopback(createUnstorageDriver(storage));
+    expect(await read(fresh, "/f")).toBe("bb");
+  });
+
+  it("keeps a concurrent write dirty while a flush is pending", async () => {
+    const backing = memoryStorageDriver();
+    let delayNextWrite = false;
+    let reached!: () => void;
+    let resume!: () => void;
+    const pending = new Promise<void>((resolve) => {
+      reached = resolve;
+    });
+    const gate = new Promise<void>((resolve) => {
+      resume = resolve;
+    });
+    const storage = createStorage({
+      driver: {
+        ...backing,
+        async setItemRaw(key, value, options) {
+          if (delayNextWrite) {
+            delayNextWrite = false;
+            reached();
+            await gate;
+          }
+          await backing.setItemRaw!(key, value, options);
+        },
+      },
+    });
+    const fs = createLoopback(createUnstorageDriver(storage));
+    await fs.writeFile("/f", "aaaa");
+    const first = await fs.open("/f", "r+");
+    const second = await fs.open("/f", "r+");
+    await first.write(new TextEncoder().encode("bbbb"), 0, 4, 0);
+
+    delayNextWrite = true;
+    const syncing = first.sync!();
+    await pending;
+    await second.write(new TextEncoder().encode("cccc"), 0, 4, 0);
+    resume();
+    await syncing;
+    await first.close();
+    await second.close();
+
+    expect(await stored(storage, "f")).toBe("cccc");
+  });
+
+  it("does not keep a clean buffer after a renamed file closes", async () => {
+    const { fs, storage } = setup();
+    await fs.writeFile("/from", "old");
+    const handle = await fs.open("/from", "r");
+    await fs.rename("/from", "/to");
+    await handle.close();
+
+    await storage.setItemRaw("to", new TextEncoder().encode("fresh"));
+    expect(await read(fs, "/to")).toBe("fresh");
+  });
+
+  it("persists a renamed open file through a fresh fs-lite driver", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mountx-unstorage-"));
+    try {
+      const firstStorage = createStorage({ driver: fsLiteStorageDriver({ base: root }) });
+      const first = createLoopback(createUnstorageDriver(firstStorage));
+      await first.writeFile("/from", "aaaa");
+      const handle = await first.open("/from", "r+");
+      await handle.write(new TextEncoder().encode("bb"), 0, 2, 0);
+      await first.rename("/from", "/to");
+      await handle.write(new TextEncoder().encode("cc"), 0, 2, 2);
+      await handle.close();
+
+      const freshStorage = createStorage({ driver: fsLiteStorageDriver({ base: root }) });
+      const fresh = createLoopback(createUnstorageDriver(freshStorage));
+      await expect(fresh.stat("/from")).rejects.toMatchObject({ code: "ENOENT" });
+      expect(await read(fresh, "/to")).toBe("bbcc");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## What changed

- Keep the current path on the shared `OpenFile` and remap it with the rest of the subtree during direct and ancestor renames.
- Route handle writeback, metadata, release, and stats through that live path, so closing an old handle cannot resurrect the old key.
- Retain dirty buffers after a rejected writeback, remove clean zero-reference buffers, and persist path-based truncation when no closer remains.
- Preserve writes made while an older flush is pending without adding a revision or writeback-queue abstraction.
- Add shared handle conformance plus unstorage backing-store, failure, concurrency, stale-buffer, and `fs-lite` persistence coverage.

## Why

This addresses Group C of #1. `createFileHandle` captured the path passed to `open`, while `movePaths` only re-keyed the shared record. A handle that survived rename therefore flushed and released against the old name: the old key could be resurrected, the destination missed buffered writes, descendant handles did not follow an ancestor rename, and the record could remain permanently stale.

The existing design already treats `OpenFile` as the shared identity for bytes and references, and mountx's Node-shaped handle contract expects that identity to survive rename. Moving mutable path identity onto that same record is the narrow root-cause fix.

## Scope

This PR owns issue #1 Group C only. It does not change the public API, make unstorage rename atomic, add Group I remote-store cost work, add retry workers or generation counters, or depend on #2.

## Verification

Before the production edit, the new focused regressions deterministically reproduced old-key resurrection, stale destination bytes, direct and ancestor rename failures, failed-close data loss, zero-reference truncate divergence, and clean-buffer reuse.

After the fix:

- `pnpm test` — 897 passed, 205 skipped; includes lint, typecheck, and coverage
- focused unstorage + driver conformance — 273 passed, 17 skipped
- `pnpm build`
- committed `fs-lite` test — real temporary directory, then fresh `Storage` and mountx driver reconstruction
- external built-package E2E — write, rename, write, and close in one process; fresh-process reopen returned `bbcc` and the old key was absent
- independent Standards and Spec re-reviews — no actionable findings

The portable real-backend E2E covers a root-level file. Ancestor rename is protected by shared conformance; a nested `fs-lite` E2E currently encounters pre-existing directory classification behavior and is intentionally outside this Group C PR.
