### PR TITLE
fix(harness): complete short writes

### DIFF
--- a/src/harness.ts
+++ b/src/harness.ts
@@ -125,8 +125,14 @@ export function createLoopback(driver: FsDriver): Loopback {
       const bytes = typeof data === "string" ? encoder.encode(data) : data;
       const handle = await loopback.open(path, "w", 0o666);
       try {
-        if (bytes.byteLength > 0) {
-          await handle.write(bytes, 0, bytes.byteLength, 0);
+        let written = 0;
+        while (written < bytes.byteLength) {
+          const remaining = bytes.byteLength - written;
+          const { bytesWritten } = await handle.write(bytes, written, remaining, written);
+          if (!Number.isInteger(bytesWritten) || bytesWritten <= 0 || bytesWritten > remaining) {
+            throw fsError("EIO", { syscall: "write", path });
+          }
+          written += bytesWritten;
         }
       } finally {
         await handle.close();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -159,4 +159,51 @@ describe("harness", () => {
     await fs.writeFile("/bytes", new Uint8Array([1, 2, 3]));
     expect([...(await fs.readFile("/bytes"))]).toEqual([1, 2, 3]);
   });
+
+  it("completes short writes", async () => {
+    const backing = createMemoryDriver();
+    const calls: [number, number, number | null][] = [];
+    const fs = createLoopback({
+      ...backing,
+      async open(path, flags, mode) {
+        const handle = await backing.open(path, flags, mode);
+        return {
+          ...handle,
+          async write(buffer, offset, length, position) {
+            const start = offset ?? 0;
+            const count = Math.min(length ?? buffer.byteLength - start, 2);
+            calls.push([start, count, position ?? null]);
+            return handle.write(buffer, start, count, position);
+          },
+        };
+      },
+    });
+
+    await fs.writeFile("/short", "abcde");
+
+    expect(new TextDecoder().decode(await fs.readFile("/short"))).toBe("abcde");
+    expect(calls).toEqual([
+      [0, 2, 0],
+      [2, 2, 2],
+      [4, 1, 4],
+    ]);
+  });
+
+  it.each([0, -1, 0.5, 5])("rejects invalid write progress: %s", async (bytesWritten) => {
+    const backing = createMemoryDriver();
+    const fs = createLoopback({
+      ...backing,
+      async open(path, flags, mode) {
+        const handle = await backing.open(path, flags, mode);
+        return {
+          ...handle,
+          async write(buffer) {
+            return { bytesWritten, buffer };
+          },
+        };
+      },
+    });
+
+    await expect(fs.writeFile("/stalled", "data")).rejects.toMatchObject({ code: "EIO" });
+  });
 });


### PR DESCRIPTION
## Summary

- complete `createLoopback().writeFile()` when a Node-compatible handle reports a legitimate short write
- advance the input offset and explicit file position together
- reject impossible write progress as `EIO` instead of hanging or returning false success
- cover short and invalid progress with deterministic custom-driver regressions

Addresses Group G item 1 in #1.

## Scope

This is only the `src/harness.ts` whole-file helper fix from G1. It does not include G2-G5, transport write paths, driver performance changes, public-surface changes, or work from other pull requests.

## Original intent

`FsDriver` is deliberately a structural subset of `node:fs/promises`, and `FileHandleLike.write()` returns `bytesWritten` because a successful write can be short. Issue #1 asks this helper to loop like its existing `readFile()` counterpart. Node's own whole-file implementation also awaits and advances across repeated writes.

The guard accepts every positive integer count within the requested remainder. A zero, negative, fractional, or oversized result violates the driver contract; failing it promptly prevents an infinite loop or skipped bytes.

## Before and after

Against base `ffc0f66022f53a20ac57edb8c54af4ba4948f49d`, an external custom driver limited to two bytes per call produced `"ab"` from `"abcdefgh"` and received one call:

```text
{"actual":"ab","calls":[[0,2,0]]}
```

After this change, the packed package installed into a fresh external project produces all bytes through advancing calls:

```text
{"actual":"abcdefgh","calls":[[0,2,0],[2,2,2],[4,2,4],[6,2,6]]}
```

That packed external consumer is the relevant E2E boundary. FUSE and NFS sessions call file handles directly and do not invoke `Loopback.writeFile()`, so a real mount would not exercise this fix.

## Verification

- `pnpm exec vitest run test/index.test.ts` — 18 passed
- `pnpm test` — lint, typecheck, 888 passed and 197 skipped
- `pnpm build`
- packed-package external consumer in a fresh process
- independent Standards and Spec reviews with Ponytail and simplification checks; no actionable findings
